### PR TITLE
feat: Add build information footer with environment detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,13 @@
 {
-  "name": "vite-react-typescript-starter",
+  "name": "form-manager",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite ",
+    "dev": "vite",
     "build": "vite build",
+    "build:production": "vite build --mode production",
+    "build:github-pages": "vite build --config vite.config.github.ts",
     "build:single": "vite build --config vite.config.inline.ts",
     "lint": "eslint .",
     "preview": "vite preview",
@@ -13,7 +15,8 @@
     "test:jcc2": "playwright test tests/jcc2-dashboard-form-e2e-working.spec.ts",
     "test:ui": "playwright test --ui",
     "test:headed": "playwright test --headed",
-    "test:debug": "playwright test --debug"
+    "test:debug": "playwright test --debug",
+    "build-info": "node scripts/get-build-info.js"
   },
   "dependencies": {
     "crc-32": "^1.2.2",

--- a/scripts/get-build-info.js
+++ b/scripts/get-build-info.js
@@ -1,0 +1,51 @@
+import { execSync } from 'child_process';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function getGitInfo() {
+  try {
+    const commit = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+    const commitShort = execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim();
+    const branch = execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf8' }).trim();
+    return { commit, commitShort, branch };
+  } catch (error) {
+    console.warn('Git information not available:', error.message);
+    return { commit: 'unknown', commitShort: 'unknown', branch: 'unknown' };
+  }
+}
+
+function getPackageVersion() {
+  try {
+    const packageJson = JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf8'));
+    return packageJson.version || '0.0.0';
+  } catch (error) {
+    console.warn('Package version not available:', error.message);
+    return '0.0.0';
+  }
+}
+
+export function getBuildInfo(environment = 'development') {
+  const gitInfo = getGitInfo();
+  const version = getPackageVersion();
+  
+  return {
+    version,
+    commit: gitInfo.commit,
+    commitShort: gitInfo.commitShort,
+    branch: gitInfo.branch,
+    buildTime: new Date().toISOString(),
+    environment,
+    buildMode: process.env.NODE_ENV || environment
+  };
+}
+
+// If called directly, output JSON
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const environment = process.argv[2] || 'development';
+  const buildInfo = getBuildInfo(environment);
+  console.log(JSON.stringify(buildInfo, null, 2));
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { AppRouter } from './components/AppRouter';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { ToastProvider } from './contexts/ToastContext';
+import { Footer } from './components/Footer';
 import { storageManager } from './utils/storage';
 import { bundleAnalyzer, estimateBundleImpact } from './utils/bundleAnalyzer';
 import { FormTemplate } from './types/form';
@@ -204,8 +205,9 @@ function App() {
       }}
     >
       <ToastProvider>
-        <div className="min-h-screen bg-gray-50">
+        <div className="min-h-screen bg-gray-50 pb-12">
           <AppRouter />
+          <Footer />
         </div>
       </ToastProvider>
     </ErrorBoundary>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,123 @@
+import React, { useState } from 'react';
+import { detectRuntime, getEnvironmentLabel, getBuildInfo } from '@/utils/environment';
+import { Info, X, GitBranch, Clock, Server, Package } from 'lucide-react';
+
+export function Footer() {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const runtime = detectRuntime();
+  const buildInfo = getBuildInfo();
+  const envLabel = getEnvironmentLabel(runtime, buildInfo);
+  
+  const formatDate = (dateString: string) => {
+    try {
+      return new Date(dateString).toLocaleString();
+    } catch {
+      return dateString;
+    }
+  };
+  
+  return (
+    <footer className="fixed bottom-0 left-0 right-0 bg-gray-900 text-white text-sm z-50">
+      <div className="flex items-center justify-between px-4 py-2">
+        <div className="flex items-center gap-4">
+          <button
+            onClick={() => setIsExpanded(!isExpanded)}
+            className="flex items-center gap-2 hover:text-blue-300 transition-colors"
+            aria-label="Toggle build information"
+          >
+            {isExpanded ? <X size={16} /> : <Info size={16} />}
+            <span className="font-medium">{envLabel}</span>
+          </button>
+          
+          {!isExpanded && (
+            <>
+              <span className="text-gray-400">v{buildInfo.version}</span>
+              {buildInfo.commit !== 'local' && (
+                <span className="text-gray-400 font-mono">
+                  {buildInfo.commitShort}
+                </span>
+              )}
+            </>
+          )}
+        </div>
+        
+        {!isExpanded && (
+          <div className="text-gray-400 text-xs">
+            Form Manager {buildInfo.environment === 'production' ? 'Pro' : 'Dev'}
+          </div>
+        )}
+      </div>
+      
+      {isExpanded && (
+        <div className="border-t border-gray-700 px-4 py-3 bg-gray-800">
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 max-w-6xl">
+            <div className="flex items-start gap-2">
+              <Server size={16} className="text-gray-400 mt-0.5" />
+              <div>
+                <div className="font-medium text-gray-300">Environment</div>
+                <div className="text-gray-400">{envLabel}</div>
+                {runtime.isDevServer && (
+                  <div className="text-xs text-blue-400">HMR Enabled</div>
+                )}
+              </div>
+            </div>
+            
+            <div className="flex items-start gap-2">
+              <Package size={16} className="text-gray-400 mt-0.5" />
+              <div>
+                <div className="font-medium text-gray-300">Version</div>
+                <div className="text-gray-400">{buildInfo.version}</div>
+                <div className="text-xs text-gray-500">Build: {buildInfo.buildMode}</div>
+              </div>
+            </div>
+            
+            {buildInfo.commit !== 'local' && (
+              <div className="flex items-start gap-2">
+                <GitBranch size={16} className="text-gray-400 mt-0.5" />
+                <div>
+                  <div className="font-medium text-gray-300">Git Info</div>
+                  <div className="text-gray-400 font-mono text-xs">
+                    {buildInfo.branch} @ {buildInfo.commitShort}
+                  </div>
+                  <div className="text-xs text-gray-500">{buildInfo.commit}</div>
+                </div>
+              </div>
+            )}
+            
+            <div className="flex items-start gap-2">
+              <Clock size={16} className="text-gray-400 mt-0.5" />
+              <div>
+                <div className="font-medium text-gray-300">Build Time</div>
+                <div className="text-gray-400 text-xs">
+                  {formatDate(buildInfo.buildTime)}
+                </div>
+              </div>
+            </div>
+            
+            {runtime.isGitHubPages && (
+              <div className="flex items-start gap-2">
+                <Info size={16} className="text-gray-400 mt-0.5" />
+                <div>
+                  <div className="font-medium text-gray-300">Deployment</div>
+                  <div className="text-gray-400 text-xs">GitHub Pages</div>
+                  <div className="text-xs text-gray-500">{runtime.baseUrl}</div>
+                </div>
+              </div>
+            )}
+            
+            {runtime.isSingleFile && (
+              <div className="flex items-start gap-2">
+                <Info size={16} className="text-gray-400 mt-0.5" />
+                <div>
+                  <div className="font-medium text-gray-300">Bundle</div>
+                  <div className="text-gray-400 text-xs">Single HTML File</div>
+                  <div className="text-xs text-gray-500">All assets inlined</div>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </footer>
+  );
+}

--- a/src/types/build-info.ts
+++ b/src/types/build-info.ts
@@ -1,0 +1,23 @@
+export interface BuildInfo {
+  version: string;
+  commit: string;
+  commitShort: string;
+  branch: string;
+  buildTime: string;
+  environment: 'development' | 'production' | 'single-file' | 'github-pages';
+  buildMode: string;
+}
+
+export interface RuntimeInfo {
+  isDevServer: boolean;
+  isSingleFile: boolean;
+  isGitHubPages: boolean;
+  isProduction: boolean;
+  baseUrl: string;
+}
+
+declare global {
+  interface Window {
+    __BUILD_INFO__: BuildInfo;
+  }
+}

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -1,0 +1,45 @@
+import { BuildInfo, RuntimeInfo } from '@/types/build-info';
+
+export function detectRuntime(): RuntimeInfo {
+  const hostname = window.location.hostname;
+  const pathname = window.location.pathname;
+  const protocol = window.location.protocol;
+  
+  const isDevServer = hostname === 'localhost' || hostname === '127.0.0.1' || hostname.startsWith('192.168.');
+  const isGitHubPages = hostname.includes('github.io') || pathname.includes('/form_manager/');
+  const isSingleFile = protocol === 'file:' || (document.currentScript === null && !isDevServer);
+  const isProduction = !isDevServer && !isSingleFile;
+  
+  return {
+    isDevServer,
+    isSingleFile,
+    isGitHubPages,
+    isProduction,
+    baseUrl: window.location.origin + pathname.replace(/\/[^/]*$/, '')
+  };
+}
+
+export function getEnvironmentLabel(runtime: RuntimeInfo, buildInfo?: BuildInfo): string {
+  if (runtime.isDevServer) return 'Development Server';
+  if (runtime.isSingleFile) return 'Single File Build';
+  if (runtime.isGitHubPages) return 'GitHub Pages';
+  if (buildInfo?.environment === 'production') return 'Production';
+  return 'Unknown Environment';
+}
+
+export function getBuildInfo(): BuildInfo {
+  if (typeof window !== 'undefined' && window.__BUILD_INFO__) {
+    return window.__BUILD_INFO__;
+  }
+  
+  // Fallback for development
+  return {
+    version: 'dev',
+    commit: 'local',
+    commitShort: 'local',
+    branch: 'local',
+    buildTime: new Date().toISOString(),
+    environment: 'development',
+    buildMode: 'development'
+  };
+}

--- a/vite.config.github.ts
+++ b/vite.config.github.ts
@@ -4,9 +4,10 @@ import { getBuildInfo } from "./scripts/get-build-info.js";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
-  const buildInfo = getBuildInfo(mode === 'production' ? 'production' : 'development');
+  const buildInfo = getBuildInfo('github-pages');
   
   return {
+    base: '/form_manager/',
     plugins: [react()],
     optimizeDeps: {
       exclude: ["lucide-react"],

--- a/vite.config.inline.ts
+++ b/vite.config.inline.ts
@@ -2,72 +2,80 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { viteSingleFile } from "vite-plugin-singlefile";
 import circularDependency from "vite-plugin-circular-dependency";
+import { getBuildInfo } from "./scripts/get-build-info.js";
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [
-    react(),
-    viteSingleFile({
-      // Prevent removal of unused CSS
-      removeViteModuleLoader: false,
-    }),
-    circularDependency({
-      outputFilePath: "./circular-deps.txt",
-    }),
-  ],
-  build: {
-    // Enable source maps for better debugging
-    sourcemap: true,
-    // Use terser for better minification control
-    minify: "terser",
-    // Use a more compatible target that supports BigInt
-    target: "es2020",
-    assetsInlineLimit: 100000000, // 100MB - inline everything
-    cssCodeSplit: false,
-    terserOptions: {
-      compress: {
-        // Prevent unsafe optimizations
-        unsafe: false,
-        unsafe_comps: false,
-        unsafe_Function: false,
-        unsafe_math: false,
-        unsafe_symbols: false,
-        unsafe_methods: false,
-        unsafe_proto: false,
-        unsafe_regexp: false,
-        unsafe_undefined: false,
-        // Keep initialization order
-        sequences: false,
-        // Prevent function inlining that might cause issues
-        inline: 1,
+export default defineConfig(({ mode }) => {
+  const buildInfo = getBuildInfo('single-file');
+  
+  return {
+    plugins: [
+      react(),
+      viteSingleFile({
+        // Prevent removal of unused CSS
+        removeViteModuleLoader: false,
+      }),
+      circularDependency({
+        outputFilePath: "./circular-deps.txt",
+      }),
+    ],
+    build: {
+      // Enable source maps for better debugging
+      sourcemap: true,
+      // Use terser for better minification control
+      minify: "terser",
+      // Use a more compatible target that supports BigInt
+      target: "es2020",
+      assetsInlineLimit: 100000000, // 100MB - inline everything
+      cssCodeSplit: false,
+      terserOptions: {
+        compress: {
+          // Prevent unsafe optimizations
+          unsafe: false,
+          unsafe_comps: false,
+          unsafe_Function: false,
+          unsafe_math: false,
+          unsafe_symbols: false,
+          unsafe_methods: false,
+          unsafe_proto: false,
+          unsafe_regexp: false,
+          unsafe_undefined: false,
+          // Keep initialization order
+          sequences: false,
+          // Prevent function inlining that might cause issues
+          inline: 1,
+        },
+        mangle: {
+          // Keep function names for better debugging
+          keep_fnames: true,
+        },
+        format: {
+          // Preserve some formatting for readability
+          beautify: false,
+          comments: false,
+        },
       },
-      mangle: {
-        // Keep function names for better debugging
-        keep_fnames: true,
-      },
-      format: {
-        // Preserve some formatting for readability
-        beautify: false,
-        comments: false,
+      rollupOptions: {
+        output: {
+          inlineDynamicImports: true,
+          manualChunks: undefined,
+          // Ensure proper module format
+          format: "iife",
+          // Prevent variable name conflicts
+          intro: "const global = window;",
+        },
       },
     },
-    rollupOptions: {
-      output: {
-        inlineDynamicImports: true,
-        manualChunks: undefined,
-        // Ensure proper module format
-        format: "iife",
-        // Prevent variable name conflicts
-        intro: "const global = window;",
+    optimizeDeps: {
+      exclude: ["lucide-react"],
+    },
+    resolve: {
+      alias: {
+        "@": "/src",
       },
     },
-  },
-  optimizeDeps: {
-    exclude: ["lucide-react"],
-  },
-  resolve: {
-    alias: {
-      "@": "/src",
-    },
-  },
+    define: {
+      'window.__BUILD_INFO__': JSON.stringify(buildInfo)
+    }
+  };
 });


### PR DESCRIPTION
Implemented a footer component that displays build and environment information:
- Shows current environment (dev server, production, single file, GitHub Pages)
- Displays version, git commit info, branch, and build time
- Collapsible design to minimize screen usage
- Auto-detects runtime environment and adapts display accordingly
- Build scripts capture git information at build time
- Supports all deployment targets with environment-specific configurations

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>