### PR TITLE
feat: Integrate browser history API with form navigation

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useFormHistory';

--- a/src/hooks/useFormHistory.ts
+++ b/src/hooks/useFormHistory.ts
@@ -1,0 +1,151 @@
+import { useCallback, useRef } from 'react';
+import { FormTemplate, FormInstance } from '../types/form.types';
+
+export interface FormHistoryState {
+  routeType: 'dashboard' | 'builder' | 'form';
+  templateId?: string;
+  instanceId?: string;
+  sectionIndex?: number;
+  viewMode?: 'continuous' | 'section';
+  timestamp?: number;
+}
+
+export const useFormHistory = () => {
+  const isNavigating = useRef(false);
+
+  const buildPath = useCallback((state: FormHistoryState): string => {
+    const searchParams = new URLSearchParams();
+    
+    switch (state.routeType) {
+      case 'dashboard':
+        return '/';
+      
+      case 'builder':
+        if (state.templateId) {
+          return `/builder/${state.templateId}`;
+        }
+        return '/builder';
+      
+      case 'form':
+        if (!state.templateId) {
+          return '/';
+        }
+        
+        let path = `/form/${state.templateId}`;
+        
+        if (state.instanceId) {
+          path += `/${state.instanceId}`;
+        }
+        
+        // Add section information for section view mode
+        if (state.viewMode === 'section' && state.sectionIndex !== undefined) {
+          searchParams.set('section', state.sectionIndex.toString());
+        }
+        
+        if (state.viewMode && state.viewMode !== 'continuous') {
+          searchParams.set('view', state.viewMode);
+        }
+        
+        const queryString = searchParams.toString();
+        return queryString ? `${path}?${queryString}` : path;
+      
+      default:
+        return '/';
+    }
+  }, []);
+
+  const parseCurrentUrl = useCallback((): FormHistoryState | null => {
+    const path = window.location.pathname;
+    const searchParams = new URLSearchParams(window.location.search);
+    
+    // Dashboard route
+    if (path === '/' || path === '') {
+      return { routeType: 'dashboard' };
+    }
+    
+    // Builder routes
+    if (path.startsWith('/builder')) {
+      const matches = path.match(/^\/builder(?:\/([^\/]+))?$/);
+      if (matches) {
+        return {
+          routeType: 'builder',
+          templateId: matches[1] || undefined
+        };
+      }
+    }
+    
+    // Form routes
+    if (path.startsWith('/form')) {
+      const matches = path.match(/^\/form\/([^\/]+)(?:\/([^\/]+))?$/);
+      if (matches) {
+        const state: FormHistoryState = {
+          routeType: 'form',
+          templateId: matches[1],
+          instanceId: matches[2] || undefined
+        };
+        
+        // Parse query parameters
+        const sectionParam = searchParams.get('section');
+        if (sectionParam) {
+          const sectionIndex = parseInt(sectionParam, 10);
+          if (!isNaN(sectionIndex)) {
+            state.sectionIndex = sectionIndex;
+          }
+        }
+        
+        const viewMode = searchParams.get('view') as 'continuous' | 'section' | null;
+        if (viewMode === 'section' || viewMode === 'continuous') {
+          state.viewMode = viewMode;
+        }
+        
+        return state;
+      }
+    }
+    
+    return null;
+  }, []);
+
+  const updateUrl = useCallback((state: FormHistoryState, options?: { replace?: boolean; force?: boolean }) => {
+    const { replace = false, force = false } = options || {};
+    
+    // Prevent recursive updates
+    if (isNavigating.current && !force) {
+      return;
+    }
+    
+    const path = buildPath(state);
+    const currentPath = window.location.pathname + window.location.search;
+    
+    // Only update if path has changed
+    if (path !== currentPath || force) {
+      const stateData = { ...state, timestamp: Date.now() };
+      
+      if (replace) {
+        window.history.replaceState(stateData, '', path);
+      } else {
+        window.history.pushState(stateData, '', path);
+      }
+    }
+  }, [buildPath]);
+
+  const replaceUrlParams = useCallback((updates: Partial<FormHistoryState>) => {
+    const currentState = window.history.state as FormHistoryState || parseCurrentUrl();
+    if (currentState) {
+      const newState = { ...currentState, ...updates };
+      updateUrl(newState, { replace: true });
+    }
+  }, [parseCurrentUrl, updateUrl]);
+
+  const setNavigating = useCallback((value: boolean) => {
+    isNavigating.current = value;
+  }, []);
+
+  return {
+    buildPath,
+    parseCurrentUrl,
+    updateUrl,
+    replaceUrlParams,
+    setNavigating,
+    isNavigating
+  };
+};

--- a/src/routes/FormRoute.tsx
+++ b/src/routes/FormRoute.tsx
@@ -33,6 +33,8 @@ interface FormRouteProps {
   onSave: (instance: FormInstance) => void;
   onSubmit: (instance: FormInstance) => void;
   onExit: () => void;
+  initialSectionIndex?: number;
+  initialViewMode?: 'continuous' | 'section';
 }
 
 const FormRoute: React.FC<FormRouteProps> = ({
@@ -40,7 +42,9 @@ const FormRoute: React.FC<FormRouteProps> = ({
   instance,
   onSave,
   onSubmit,
-  onExit
+  onExit,
+  initialSectionIndex,
+  initialViewMode
 }) => {
   return (
     <FormErrorBoundary formName={template.name}>
@@ -51,6 +55,8 @@ const FormRoute: React.FC<FormRouteProps> = ({
           onSave={onSave}
           onSubmit={onSubmit}
           onExit={onExit}
+          initialSectionIndex={initialSectionIndex}
+          initialViewMode={initialViewMode}
         />
       </Suspense>
     </FormErrorBoundary>


### PR DESCRIPTION
- Add useFormHistory hook for URL state management
- Support deep linking to specific form sections and view modes
- Enable browser back/forward navigation between routes
- Sync form state (section index, view mode) with URL parameters
- Add URL patterns: /form/{templateId}/{instanceId}?section=X&view=Y

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>