### PR TITLE
feat: Add automatic index column support to DataTables

### DIFF
--- a/src/components/fields/DataTableField.tsx
+++ b/src/components/fields/DataTableField.tsx
@@ -12,9 +12,15 @@ interface DataTableFieldProps {
 }
 
 // Initialize empty row based on column definitions
-const createEmptyRow = (columns: DataTableColumn[]): DataTableRow => {
+const createEmptyRow = (columns: DataTableColumn[], rowIndex?: number): DataTableRow => {
   const row: DataTableRow = {};
   columns.forEach(col => {
+    // Auto-index columns are handled separately
+    if (col.autoIndex) {
+      row[col.id] = rowIndex !== undefined ? rowIndex + 1 : '';
+      return;
+    }
+    
     switch (col.type) {
       case 'checkbox':
         row[col.id] = [];
@@ -70,9 +76,21 @@ const DataTableField: React.FC<DataTableFieldProps> = ({
     
     if (value && value.rows) {
       // If value exists, use its rows but ensure columns come from field definition
+      // Update auto-index columns
+      const autoIndexColumns = columns.filter(col => col.autoIndex);
+      let rows = value.rows;
+      if (autoIndexColumns.length > 0) {
+        rows = value.rows.map((row, rowIndex) => {
+          const updatedRow = { ...row };
+          autoIndexColumns.forEach(col => {
+            updatedRow[col.id] = rowIndex + 1;
+          });
+          return updatedRow;
+        });
+      }
       return {
         columns,
-        rows: value.rows
+        rows
       };
     }
     
@@ -81,14 +99,14 @@ const DataTableField: React.FC<DataTableFieldProps> = ({
       const defaultVal = field.defaultValue as DataTableValue;
       return {
         columns,
-        rows: defaultVal.rows || [createEmptyRow(columns)]
+        rows: defaultVal.rows || [createEmptyRow(columns, 0)]
       };
     }
     
     // Initialize with one empty row
     return {
       columns,
-      rows: [createEmptyRow(columns)]
+      rows: [createEmptyRow(columns, 0)]
     };
   });
 
@@ -104,6 +122,14 @@ const DataTableField: React.FC<DataTableFieldProps> = ({
 
   // Handle cell value change
   const handleCellChange = (rowIndex: number, columnId: string, newValue: string | number | boolean | string[]) => {
+    // Find the column
+    const column = tableValue.columns.find(col => col.id === columnId);
+    
+    // Prevent changes to auto-index columns
+    if (column?.autoIndex) {
+      return;
+    }
+    
     const newRows = [...tableValue.rows];
     newRows[rowIndex] = {
       ...newRows[rowIndex],
@@ -116,7 +142,6 @@ const DataTableField: React.FC<DataTableFieldProps> = ({
     });
 
     // Validate the cell
-    const column = tableValue.columns.find(col => col.id === columnId);
     if (column) {
       const error = validateCellValue(newValue, column);
       const errorKey = `${rowIndex}-${columnId}`;
@@ -135,9 +160,10 @@ const DataTableField: React.FC<DataTableFieldProps> = ({
   const addRow = () => {
     const maxRows = field.maxRows || field.validation?.maxRows;
     if (!maxRows || tableValue.rows.length < maxRows) {
+      const newRowIndex = tableValue.rows.length;
       setTableValue({
         ...tableValue,
-        rows: [...tableValue.rows, createEmptyRow(tableValue.columns)]
+        rows: [...tableValue.rows, createEmptyRow(tableValue.columns, newRowIndex)]
       });
     }
   };
@@ -146,7 +172,20 @@ const DataTableField: React.FC<DataTableFieldProps> = ({
   const removeRow = (index: number) => {
     const minRows = field.minRows || field.validation?.minRows || 1;
     if (tableValue.rows.length > minRows) {
-      const newRows = tableValue.rows.filter((_, i) => i !== index);
+      let newRows = tableValue.rows.filter((_, i) => i !== index);
+      
+      // Re-index auto-index columns
+      const autoIndexColumns = tableValue.columns.filter(col => col.autoIndex);
+      if (autoIndexColumns.length > 0) {
+        newRows = newRows.map((row, rowIndex) => {
+          const updatedRow = { ...row };
+          autoIndexColumns.forEach(col => {
+            updatedRow[col.id] = rowIndex + 1;
+          });
+          return updatedRow;
+        });
+      }
+      
       setTableValue({
         ...tableValue,
         rows: newRows
@@ -170,6 +209,22 @@ const DataTableField: React.FC<DataTableFieldProps> = ({
     const cellError = cellErrors[errorKey];
     const columnHeaderId = `${field.id}-header-${column.id}`;
     const inputId = `${field.id}-${rowIndex}-${column.id}`;
+    
+    // Handle auto-index columns
+    if (column.autoIndex) {
+      const autoIndexValue = rowIndex + 1;
+      return (
+        <input
+          id={inputId}
+          aria-labelledby={columnHeaderId}
+          type="number"
+          value={autoIndexValue}
+          readOnly
+          className="w-full px-2 py-1 border rounded bg-gray-50 border-gray-300 cursor-not-allowed"
+          disabled={true}
+        />
+      );
+    }
     
     const baseInputClasses = `w-full px-2 py-1 border rounded focus:outline-none focus:ring-1 focus:ring-blue-500 ${
       cellError ? 'border-red-500' : 'border-gray-300'

--- a/src/programmatic/tdl/converter.ts
+++ b/src/programmatic/tdl/converter.ts
@@ -186,7 +186,13 @@ export class TDLConverter {
       grouping: guiField.grouping,
       validation: guiField.validation,
       conditional: guiField.conditional,
-      defaultValue: guiField.defaultValue
+      defaultValue: guiField.defaultValue,
+      // DataTable specific properties
+      columns: guiField.columns,
+      allowAddRows: guiField.allowAddRows,
+      allowDeleteRows: guiField.allowDeleteRows,
+      minRows: guiField.minRows,
+      maxRows: guiField.maxRows
     };
 
     return programmaticField;
@@ -288,7 +294,13 @@ export class TDLConverter {
       grouping: programmaticField.grouping,
       validation: programmaticField.validation,
       conditional: programmaticField.conditional,
-      defaultValue: programmaticField.defaultValue
+      defaultValue: programmaticField.defaultValue,
+      // DataTable specific properties
+      columns: programmaticField.columns,
+      allowAddRows: programmaticField.allowAddRows,
+      allowDeleteRows: programmaticField.allowDeleteRows,
+      minRows: programmaticField.minRows,
+      maxRows: programmaticField.maxRows
     };
 
     return guiField;
@@ -302,7 +314,7 @@ export class TDLConverter {
     if (guiType === 'text' || guiType === 'textarea' || guiType === 'select' || 
         guiType === 'radio' || guiType === 'checkbox' || guiType === 'number' || 
         guiType === 'date' || guiType === 'file' || guiType === 'email' || 
-        guiType === 'tel') {
+        guiType === 'tel' || guiType === 'datatable') {
       return guiType;
     }
     
@@ -324,7 +336,8 @@ export class TDLConverter {
         programmaticType === 'select' || programmaticType === 'radio' || 
         programmaticType === 'checkbox' || programmaticType === 'number' || 
         programmaticType === 'date' || programmaticType === 'file' ||
-        programmaticType === 'email' || programmaticType === 'tel') {
+        programmaticType === 'email' || programmaticType === 'tel' ||
+        programmaticType === 'datatable') {
       return programmaticType;
     }
     

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -15,6 +15,7 @@ export interface DataTableColumn {
     maxLength?: number;
     pattern?: string;
   };
+  autoIndex?: boolean; // If true, this column will be automatically populated with row index (1-based)
 }
 
 export interface DataTableRow {

--- a/templates/jcc2_data_collection_form_v3.ts
+++ b/templates/jcc2_data_collection_form_v3.ts
@@ -213,12 +213,14 @@ export class JCC2DataCollectionFormV3 {
           type: "number",
           required: true,
           validation: { min: 1 },
+          autoIndex: true,
         },
         {
           id: "application_used",
           label: "Application Used",
-          type: "text",
+          type: "select",
           required: true,
+          options: jcc2Applications.map((app) => app.name),
         },
         {
           id: "data_gathering_supported",
@@ -312,6 +314,7 @@ export class JCC2DataCollectionFormV3 {
           type: "number",
           required: true,
           validation: { min: 1 },
+          autoIndex: true,
         },
         {
           id: "application_used",
@@ -395,6 +398,7 @@ export class JCC2DataCollectionFormV3 {
           type: "number",
           required: true,
           validation: { min: 1 },
+          autoIndex: true,
         },
         {
           id: "application_used",
@@ -486,6 +490,7 @@ export class JCC2DataCollectionFormV3 {
           type: "number",
           required: true,
           validation: { min: 1 },
+          autoIndex: true,
         },
         {
           id: "application_used",
@@ -579,6 +584,7 @@ export class JCC2DataCollectionFormV3 {
           type: "number",
           required: true,
           validation: { min: 1 },
+          autoIndex: true,
         },
         {
           id: "application_used",

--- a/templates/jcc2_data_collection_form_v3.ts
+++ b/templates/jcc2_data_collection_form_v3.ts
@@ -72,11 +72,11 @@ function toId(str: string) {
  */
 function addStandardTaskQuestions(builder: TemplateBuilder, sectionId: string) {
   // Add a divider for visual separation
-  builder
-    .field("text", "")
-    .id(`${sectionId}_task_questions_divider`)
-    .withContent("---")
-    .end();
+  // builder
+  //   .field("text", "")
+  //   .id(`${sectionId}_task_questions_divider`)
+  //   .withContent("---")
+  //   .end();
 
   standardTaskQuestions.forEach((question) => {
     builder


### PR DESCRIPTION
- Add autoIndex property to DataTableColumn type for auto-numbered rows
- Implement read-only rendering for auto-index columns with gray background
- Automatically re-index rows when adding or removing rows
- Update JCC2 v3 template to use auto-index for all "Run" columns
- Add dropdown selection for Application Used field in JCC2 template

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>